### PR TITLE
Revert "58 error at least 80 of man pages documenting exported objects must have runnable examples"

### DIFF
--- a/R/plot_fxns.R
+++ b/R/plot_fxns.R
@@ -21,15 +21,7 @@ NULL
 #' @param ... Other parameters to pass to  [ComplexHeatmap::Heatmap()]
 #' @return a Heatmap rendered to the active graphics device
 #' @export signaling_heatmap
-#' @examples
-#' #basic usage
-#' signaling_heatmap(dom)
-#' #scale
-#' signaling_heatmap(dom, scale = "sqrt")
-#' #normalize
-#' signaling_heatmap(dom, normalize = "rec_norm")
-#'
- 
+#' 
 signaling_heatmap <- function(dom, clusts = NULL, min_thresh = -Inf, max_thresh = Inf, scale = "none",
   normalize = "none", ...) {
   if (!dom@misc[["build"]]) {
@@ -84,9 +76,6 @@ signaling_heatmap <- function(dom, clusts = NULL, min_thresh = -Inf, max_thresh 
 #' @param ... Other parameters to pass to  [ComplexHeatmap::Heatmap()]. Note that to use the 'column_title' parameter of  [ComplexHeatmap::Heatmap()]  you must set title = FALSE
 #' @return a Heatmap rendered to the active graphics device
 #' @export incoming_signaling_heatmap
-#' @examples
-#' #incoming signaling of the CD8  T cells
-#' incoming_signaling_heatmap(dom, "CD8_T_cell")
 #' 
 incoming_signaling_heatmap <- function(dom, rec_clust, clusts = NULL, min_thresh = -Inf, max_thresh = Inf,
   scale = "none", normalize = "none", title = TRUE, ...) {
@@ -175,12 +164,6 @@ incoming_signaling_heatmap <- function(dom, rec_clust, clusts = NULL, min_thresh
 #' @param ... Other parameters to be passed to plot when used with an `{igraph}` object.
 #' @return an igraph rendered to the active graphics device
 #' @export signaling_network
-#' @examples 
-#' #basic usage
-#' signaling_network(dom)
-#' # scaling, thresholds, layouts, selecting clusters
-#' signaling_network(dom, showOutgoingSignalingClusts = "CD14_monocyte", scale = "none",
-#'  norm = "none", layout = "fr", scale_by = "none", vert_scale = 5)
 #' 
 signaling_network <- function(dom, cols = NULL, edge_weight = 0.3, clusts = NULL, showOutgoingSignalingClusts = NULL,
   showIncomingSignalingClusts = NULL, min_thresh = -Inf, max_thresh = Inf, normalize = "none", scale = "sq",
@@ -313,12 +296,6 @@ signaling_network <- function(dom, cols = NULL, edge_weight = 0.3, clusts = NULL
 #' @param ... Other parameters to pass to plot() with an [igraph] object. See [igraph] manual for options.
 #' @return an igraph rendered to the active graphics device
 #' @export gene_network
-#' @examples
-#' #basic usage
-#' gene_network(dom, clust = "CD16_monocyte", OutgoingSignalingClust = "CD14_monocyte")
-#' #scaling and coloring
-#' gene_network(dom, clust = "CD16_monocyte", OutgoingSignalingClust = "CD14_monocyte",
-#'  cols = c("CD1D" = "violet", "LILRB2" = "violet", "FOSB" = "violet"), lig_scale = 10)
 #' 
 gene_network <- function(dom, clust = NULL, OutgoingSignalingClust = NULL, class_cols = c(lig = "#FF685F",
   rec = "#47a7ff", feat = "#39C740"), cols = NULL, lig_scale = 1, layout = "grid", ...) {
@@ -474,11 +451,6 @@ gene_network <- function(dom, clust = NULL, OutgoingSignalingClust = NULL, class
 #' @param ... Other parameters to pass to  [ComplexHeatmap::Heatmap()] . Note that to use the 'main' parameter of  [ComplexHeatmap::Heatmap()]  you must set title = FALSE and to use 'annCol' or 'annColors' ann_cols must be FALSE.
 #' @return a Heatmap rendered to the active graphics device
 #' @export feat_heatmap
-#' @examples 
-#' #basic usage
-#' feat_heatmap(dom)
-#' #using thresholds
-#' feat_heatmap(dom, min_thresh = 0.1, max_thresh = 0.6, norm = TRUE, bool = FALSE)
 #' 
 feat_heatmap <- function(dom, feats = NULL, bool = FALSE, bool_thresh = 0.2, title = TRUE, norm = FALSE,
   cols = NULL, ann_cols = TRUE, min_thresh = NULL, max_thresh = NULL, ...) {
@@ -594,13 +566,6 @@ feat_heatmap <- function(dom, feats = NULL, bool = FALSE, bool_thresh = 0.2, tit
 #' @param ... Other parameters to pass to  [ComplexHeatmap::Heatmap()] . Note that to use the 'main' parameter of  [ComplexHeatmap::Heatmap()]  you must set title = FALSE and to use 'annCol' or 'annColors' ann_cols must be FALSE.
 #' @return a Heatmap rendered to the active graphics device
 #' @export cor_heatmap
-#' @examples 
-#' #basic usage
-#' cor_heatmap(dom, title = "PBMC R-TF Correlations")
-#' #show correlations above a specific value
-#' cor_heatmap(dom, bool = TRUE, bool_thresh = 0.25)
-#' #identify combinations that are connected
-#' cor_heatmap(dom, bool = FALSE, mark_connections = TRUE)
 #' 
 cor_heatmap <- function(dom, bool = FALSE, bool_thresh = 0.15, title = TRUE, feats = NULL, recs = NULL,
   mark_connections = FALSE, ...) {
@@ -688,9 +653,6 @@ cor_heatmap <- function(dom, bool = FALSE, bool_thresh = 0.15, title = TRUE, fea
 #' @param ... Other parameters to pass to ggscatter.
 #' @return a ggplot object
 #' @export cor_scatter
-#' @examples 
-#' #basic usage
-#' cor_scatter(dom, "FOSB", "CD74")
 #' 
 cor_scatter <- function(dom, tf, rec, remove_rec_dropout = TRUE, ...) {
   if (remove_rec_dropout) {
@@ -717,13 +679,6 @@ cor_scatter <- function(dom, tf, rec, remove_rec_dropout = TRUE, ...) {
 #' @param cell_colors Named vector of color names or hex codes where names correspond to the plotted cell types and the color values
 #' @return renders a circos plot to the active graphics device
 #' @export circos_ligand_receptor
-#' @examples 
-#' #basic usage
-#' circos_ligand_receptor(dom, receptor = "CD74")
-#' #specify colors
-#' cols = c("red", "orange", "green", "blue", "pink", "purple", "slategrey", "firebrick", "hotpink")
-#' names(cols) = levels(dom@clusters)
-#' circos_ligand_receptor(dom, receptor = "CD74", cell_colors = cols)
 #' 
 circos_ligand_receptor <- function(dom, receptor, ligand_expression_threshold = 0.01, cell_idents = NULL,
   cell_colors = NULL) {

--- a/man/circos_ligand_receptor.Rd
+++ b/man/circos_ligand_receptor.Rd
@@ -30,12 +30,3 @@ renders a circos plot to the active graphics device
 Creates a chord plot of expression of ligands that can activate a specified
 receptor where chord widths correspond to mean ligand expression by the cluster.
 }
-\examples{
-#basic usage
-circos_ligand_receptor(dom, receptor = "CD74")
-#specify colors
-cols = c("red", "orange", "green", "blue", "pink", "purple", "slategrey", "firebrick", "hotpink")
-names(cols) = levels(dom@clusters)
-circos_ligand_receptor(dom, receptor = "CD74", cell_colors = cols)
-
-}

--- a/man/cor_heatmap.Rd
+++ b/man/cor_heatmap.Rd
@@ -39,12 +39,3 @@ a Heatmap rendered to the active graphics device
 Creates a heatmap of correlation values between receptors and transcription
 factors either with boolean threshold or with continuous values displayed
 }
-\examples{
-#basic usage
-cor_heatmap(dom, title = "PBMC R-TF Correlations")
-#show correlations above a specific value
-cor_heatmap(dom, bool = TRUE, bool_thresh = 0.25)
-#identify combinations that are connected
-cor_heatmap(dom, bool = FALSE, mark_connections = TRUE)
-
-}

--- a/man/cor_scatter.Rd
+++ b/man/cor_scatter.Rd
@@ -23,8 +23,3 @@ a ggplot object
 \description{
 Create a correlation plot between transcription factor activation score and receptor
 }
-\examples{
-#basic usage
-cor_scatter(dom, "FOSB", "CD74")
-
-}

--- a/man/feat_heatmap.Rd
+++ b/man/feat_heatmap.Rd
@@ -48,10 +48,3 @@ a Heatmap rendered to the active graphics device
 Creates a heatmap of feature expression (typically transcription factor
 activation scores) by cells organized by cluster.
 }
-\examples{
-#basic usage
-feat_heatmap(dom)
-#using thresholds
-feat_heatmap(dom, min_thresh = 0.1, max_thresh = 0.6, norm = TRUE, bool = FALSE)
-
-}

--- a/man/gene_network.Rd
+++ b/man/gene_network.Rd
@@ -41,11 +41,3 @@ selected cluster acts as the receptor for the gene association network, so
 only ligands, receptors, and features associated with the receptor cluster
 will be included in the plot.
 }
-\examples{
-#basic usage
-gene_network(dom, clust = "CD16_monocyte", OutgoingSignalingClust = "CD14_monocyte")
-#scaling and coloring
-gene_network(dom, clust = "CD16_monocyte", OutgoingSignalingClust = "CD14_monocyte",
- cols = c("CD1D" = "violet", "LILRB2" = "violet", "FOSB" = "violet"), lig_scale = 10)
-
-}

--- a/man/incoming_signaling_heatmap.Rd
+++ b/man/incoming_signaling_heatmap.Rd
@@ -46,8 +46,3 @@ ligands. A list of all cluster incoming signaling matrices can be found in
 the cl_signaling_matrices slot of a domino option as an alternative to this
 plotting function.
 }
-\examples{
-#incoming signaling of the CD8  T cells
-incoming_signaling_heatmap(dom, "CD8_T_cell")
-
-}

--- a/man/signaling_heatmap.Rd
+++ b/man/signaling_heatmap.Rd
@@ -36,12 +36,3 @@ a Heatmap rendered to the active graphics device
 Creates a heatmap of the signaling network. Alternatively, the network
 matrix can be accessed directly in the signaling slot of a domino object.
 }
-\examples{
-#basic usage
-signaling_heatmap(dom)
-#scale
-signaling_heatmap(dom, scale = "sqrt")
-#normalize
-signaling_heatmap(dom, normalize = "rec_norm")
-
-}

--- a/man/signaling_network.Rd
+++ b/man/signaling_network.Rd
@@ -61,11 +61,3 @@ Creates a network diagram of signaling between clusters. Nodes are clusters
 and directed edges indicate signaling from one cluster to another. Edges are
 colored based on the color scheme of the ligand expressing cluster.
 }
-\examples{
-#basic usage
-signaling_network(dom)
-# scaling, thresholds, layouts, selecting clusters
-signaling_network(dom, showOutgoingSignalingClusts = "CD14_monocyte", scale = "none",
- norm = "none", layout = "fr", scale_by = "none", vert_scale = 5)
-
-}


### PR DESCRIPTION
Reverts FertigLab/domino2#59