### PR TITLE
Github workflows

### DIFF
--- a/.github/copy_to_branch.sh
+++ b/.github/copy_to_branch.sh
@@ -1,0 +1,29 @@
+# Designate desired directories and files
+SRC_FOLDER_PATHS=(data-raw man R tests vignettes)
+SRC_FILE_PATHS=(DESCRIPTION LICENSE NAMESPACE NEWS.md README.md inst/CITATION)
+
+# Get files from directories
+FILES=$(find "${SRC_FOLDER_PATHS[@]}" -type f)
+
+# Add indicated individual files
+for F in "${SRC_FILE_PATHS[@]}"
+do
+FILES+=" ${F}"
+done
+
+echo "${FILES[@]}"
+
+# Pass these to github:
+git config --global user.name 'GitHub Action'
+git config --global user.email 'action@github.com'
+# Fetch branches
+git fetch
+# Checkout target branch                         
+git checkout $TARGET_BRANCH
+# Copy files in $FILES list from workflow test branch
+git checkout krishnan_workflow_test -- $FILES
+# Commit to the repository (ignore if no changes)
+git add -A
+git diff-index --quiet HEAD ||  git commit -am "update files"
+# Push to remote branch
+git push origin $TARGET_BRANCH 

--- a/.github/workflows/bioc_branch.yml
+++ b/.github/workflows/bioc_branch.yml
@@ -1,4 +1,22 @@
 name: Update Bioconductor package files
 
 on:
+  push:
+    branches: [main, master]
+  pull_request:
+    branches: [main, master]
+  release:
+    types: [published]
   workflow_dispatch:
+
+jobs:
+  copy:
+    name: Copy files
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: copy
+        env:
+          TARGET_BRANCH: 'krishnan_bioc_test'
+        run: .github/copy_to_branch.sh
+        shell: bash

--- a/.github/workflows/document.yaml
+++ b/.github/workflows/document.yaml
@@ -1,0 +1,43 @@
+# Workflow derived from https://github.com/r-lib/actions/tree/v2/examples
+# Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
+on:
+    push:
+      paths: ["R/**"]
+    workflow_dispatch:
+  
+name: documentation-update
+  
+jobs:
+    document:
+      runs-on: ubuntu-latest
+      env:
+        GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+      steps:
+        - name: Checkout repo
+          uses: actions/checkout@v3
+          with:
+            fetch-depth: 0
+  
+        - name: Setup R
+          uses: r-lib/actions/setup-r@v2
+          with:
+            use-public-rspm: true
+  
+        - name: Install dependencies
+          uses: r-lib/actions/setup-r-dependencies@v2
+          with:
+            extra-packages: any::roxygen2
+            needs: roxygen2
+  
+        - name: Document
+          run: roxygen2::roxygenise()
+          shell: Rscript {0}
+  
+        - name: Commit and push changes
+          run: |
+            git config --local user.name "$GITHUB_ACTOR"
+            git config --local user.email "$GITHUB_ACTOR@users.noreply.github.com"
+            git add man/\* NAMESPACE DESCRIPTION
+            git commit -m "Update documentation" || echo "No changes to commit"
+            git pull --ff-only
+            git push origin

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -1,0 +1,48 @@
+# Workflow derived from https://github.com/r-lib/actions/tree/v2/examples
+# Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+    branches: [main, master]
+  release:
+    types: [published]
+  workflow_dispatch:
+
+name: pkgdown-update
+
+jobs:
+  pkgdown:
+    runs-on: ubuntu-latest
+    # Only restrict concurrency for non-PR jobs
+    concurrency:
+      group: pkgdown-${{ github.event_name != 'pull_request' || github.run_id }}
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: r-lib/actions/setup-pandoc@v2
+
+      - uses: r-lib/actions/setup-r@v2
+        with:
+          use-public-rspm: true
+
+      - uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          extra-packages: any::pkgdown
+          needs: website
+
+      - name: Build site
+        run: pkgdown::build_site_github_pages(new_process = FALSE, install = TRUE)
+        shell: Rscript {0}
+
+      - name: Deploy to GitHub pages 🚀
+        if: github.event_name != 'pull_request'
+        uses: JamesIves/github-pages-deploy-action@v4.4.1
+        with:
+          clean: false
+          branch: gh-pages
+          folder: docs


### PR DESCRIPTION
In order to preserve a clean branch that follows bioconductor specifications, while maintaining an up-to-date website built off of our package, some workflows have been created.

`bioc_update` should, on a push to the master branch or a new release, update a bioconductor branch with files that have changed (but only if those files are part of the package itself).

`document` should, on a push with any changes to the R/ directory of a branch, run `roxygen2::roxygenise()` to ensure documentation for the package is kept up to date.

`pkgdown` should, on a push to the master branch or a new release, update our gh-pages branch by running `pkgdown::build_site()` to ensure that the documentation website remains up to date.